### PR TITLE
fix: fixed screen reader misinterpreting menu and accordion butt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,9 +1347,9 @@
       "dev": true
     },
     "node_modules/aria-ease": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/aria-ease/-/aria-ease-1.3.2.tgz",
-      "integrity": "sha512-gdJf96R1Z7lvlD5jVndjszzqjXvg4WJtM39GifvI0ESynKZu/e0F1vTIRyMrLVkLXITP968fBNrjzlHQoPnOkQ=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/aria-ease/-/aria-ease-1.3.4.tgz",
+      "integrity": "sha512-AcPmmlMahYWi9MRdd3iggg9wprLYJh7n6lfhW5DlBxebxEnL9OgVqTF4xLuso8CA29bcMe4IzjVU72d1x8IjXw=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -34,7 +34,7 @@ const Header = ({darkMode, setDarkMode, showDropdownPage, setShowDropdownPage}) 
         </div>
         <div className='header-buttons-grid-div' id="header-buttons-grid-div">
             <a href="https://github.com/aria-ease/aria-ease" aria-label="Navigate to project's GitHub repository" className='header-button block-interactive center-flex'><FaGithub className='header-button-icon'/></a>
-            <button className='header-button block-interactive center-flex' onMouseDown={() => {setDarkMode((prevDarkMode) => !prevDarkMode)}} onKeyDown={(event) => {if(event.key === 'Enter' || event.key === " ") {event.preventDefault(); event.stopPropagation(); setDarkMode((prevDarkMode) => !prevDarkMode)}}}>
+            <button className='header-button block-interactive center-flex' onMouseDown={() => {setDarkMode((prevDarkMode) => !prevDarkMode)}} onKeyDown={(event) => {if(event.key === 'Enter' || event.key === " ") {event.preventDefault(); event.stopPropagation(); setDarkMode((prevDarkMode) => !prevDarkMode)}}} aria-label='Toggle dark mode'>
                 <img src={sunicon} alt='Sun Icon' id='Sun' className='theme-mode-image'></img>
             </button>
         </div>

--- a/src/components/accordions/AccordionExample.jsx
+++ b/src/components/accordions/AccordionExample.jsx
@@ -5,9 +5,9 @@ import { updateAccordionTriggerAriaAttributes } from 'aria-ease'
 
 const AccordionExample = () => {
   const[isAccordionShown, setIsAccordionShown] = useState([
-    {display: false, closedAriaLabel: 'Expand information on how to make appointment', openedAriaLabel: 'Collapse information on how to make appointment'},
-    {display: false, closedAriaLabel: 'Expand information on how to get copy of records', openedAriaLabel: 'Collapse information on how to get copy of records'},
-    {display: false, closedAriaLabel: 'Expand information on extra charge for copy of records', openedAriaLabel: 'Collapse information on extra charge for copy of records'}
+    {display: false, closedAriaLabel: 'Expand information on how to make appointment accordion', openedAriaLabel: 'Collapse information on how to make appointment accordion'},
+    {display: false, closedAriaLabel: 'Expand information on how to get copy of records accordion', openedAriaLabel: 'Collapse information on how to get copy of records accordion'},
+    {display: false, closedAriaLabel: 'Expand information on extra charge for copy of records accordion', openedAriaLabel: 'Collapse information on extra charge for copy of records accordion'}
   ])
 
   const handleAccordionClick = (event, index) => {
@@ -27,7 +27,7 @@ const AccordionExample = () => {
   return (
     <div className='faq-div'>
             <div className='faq-each-div'>
-                <button id='make-an-appointment' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 0)} onMouseDown={(event) => handleAccordionClick(event, 0)} aria-pressed={false} aria-expanded={false} aria-label='Expand information on how to make appointment'>
+                <button id='make-an-appointment' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 0)} onMouseDown={(event) => handleAccordionClick(event, 0)} aria-expanded={false} aria-label='Expand information on how to make appointment accordion' type="button" role='button' aria-controls='makeAnAppointmentAccordion'>
                     <span className='dropdown-heading-text'>How do I make an appointment?</span>
                     {isAccordionShown[0].display ? 
                         <img src={openeddropdown} alt='Dropdown Icon' className='dropdown-icon-image'></img> :
@@ -35,7 +35,7 @@ const AccordionExample = () => {
                     }
                 </button>
                 {isAccordionShown[0].display ? 
-                    <div className='faq-each-text-div'>
+                    <div className='faq-each-text-div' id='makeAnAppointmentAccordion' aria-labelledby='make-an-appointment'>
                         <p>If you would like to make an appointent with any one of our practitioners, please contact our reception staff. Alternatively you can book an appointment online. Every effort will be made to accomodate your preferred time and choice of practitioner</p>
                     </div> : 
                     null
@@ -43,7 +43,7 @@ const AccordionExample = () => {
             </div>
 
             <div className='faq-each-div'>
-                <button id='copy-of-record' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 1)} onMouseDown={(event) => handleAccordionClick(event, 1)} aria-pressed={false} aria-expanded={false} aria-label='Expand information on how to get copy of records'>
+                <button id='copy-of-record' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 1)} onMouseDown={(event) => handleAccordionClick(event, 1)} aria-expanded={false} aria-label='Expand information on how to get copy of records accordion' type="button" role="button" aria-controls='copyOfRecordsAccordion'>
                     <span className='dropdown-heading-text'>How do I get a copy of my record?</span>
                     {isAccordionShown[1].display ? 
                         <img src={openeddropdown} alt='Dropdown Icon' className='dropdown-icon-image'></img> :
@@ -51,7 +51,7 @@ const AccordionExample = () => {
                     }
                 </button>
                 {isAccordionShown[1].display ? 
-                    <div className='faq-each-text-div'>
+                    <div className='faq-each-text-div' id="copyOfRecordsAccordion" aria-labelledby='copy-of-record'>
                         <p>If you would like to get a copy of your record, please contact our customer support team. Alternatively you can come into the hospital.</p>
                     </div> : 
                     null
@@ -59,7 +59,7 @@ const AccordionExample = () => {
             </div>
 
             <div className='faq-each-div'>
-                <button id='extra-charge' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 2)} onMouseDown={(event) => handleAccordionClick(event, 2)} aria-pressed={false} aria-expanded={false} aria-label='Expand information on extra charge for copy of record'>
+                <button id='extra-charge' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 2)} onMouseDown={(event) => handleAccordionClick(event, 2)} aria-expanded={false} aria-label='Expand information on extra charge for copy of record accordion' type="button" role='button' aria-controls='extraCopyChargeAccordion'>
                     <span className='dropdown-heading-text'>Is there a charge for extra copies?</span>
                     {isAccordionShown[2].display ? 
                         <img src={openeddropdown} alt='Dropdown Icon' className='dropdown-icon-image'></img> :
@@ -67,7 +67,7 @@ const AccordionExample = () => {
                     }
                 </button>
                 {isAccordionShown[2].display ? 
-                    <div className='faq-each-text-div'>
+                    <div className='faq-each-text-div' id='extraCopyChargeAccordion' aria-labelledby='extra-charge'>
                         <p>The first copy is free and subsequent copies cost $1 per copy. This cost covers printing and mailing.</p>
                     </div> : 
                     null

--- a/src/components/menus/HomeExampleMenu.jsx
+++ b/src/components/menus/HomeExampleMenu.jsx
@@ -7,7 +7,7 @@ const HomeExampleMenu = () => {
       const menu = document.querySelector('#custom-menu');
       if (getComputedStyle(menu).display === 'none') {
         menu.style.display = 'block';
-        makeMenuAccessible('custom-menu', 'profile-menu-item');
+        makeMenuAccessible('custom-menu', 'profile-menu-item', 'Display profile menu');
         updateMenuTriggerAriaAttributes('display-button', 'Hide profile menu');
       } else {
         cleanUpMenuEventListeners('custom-menu', 'profile-menu-item');
@@ -23,7 +23,7 @@ const HomeExampleMenu = () => {
         id="display-button"
         onMouseDown={toggleMenuDisplay}
         aria-haspopup={true}
-        aria-pressed={false}
+        role="button"
         aria-expanded={false}
         aria-controls="custom-menu"
         aria-label="Display profile menu"

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -369,7 +369,6 @@ select:-moz-autofill {
 .accordion-example-page-div .side-body-div p {
     margin-top: 20px;
 }
-
 .faq-each-div {
     margin: 20px 0px 0px 0px;
 }

--- a/src/pages/Accordions.jsx
+++ b/src/pages/Accordions.jsx
@@ -35,7 +35,7 @@ const AccordionExample = () => {
   return (
     <div className='faq-div'>
       <div className='faq-each-div'>
-        <button id='make-an-appointment' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 0)} onMouseDown={(event) => handleAccordionClick(event, 0)} aria-pressed={false} aria-expanded={false} aria-label='Expand information on how to make appointment'>
+        <button id='make-an-appointment' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 0)} onMouseDown={(event) => handleAccordionClick(event, 0)} aria-expanded={false} aria-label='Expand information on how to make appointment'>
           <span className='dropdown-heading-text'>How do I make an appointment?</span>
           {isAccordionShown[0].display ? 
             <img src={openeddropdown} alt='Dropdown Icon' className='dropdown-icon-image'></img> :
@@ -51,7 +51,7 @@ const AccordionExample = () => {
       </div>
 
       <div className='faq-each-div'>
-        <button id='copy-of-record' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 1)} onMouseDown={(event) => handleAccordionClick(event, 1)} aria-pressed={false} aria-expanded={false} aria-label='Expand information on how to get copy of records'>
+        <button id='copy-of-record' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 1)} onMouseDown={(event) => handleAccordionClick(event, 1)} aria-expanded={false} aria-label='Expand information on how to get copy of records'>
           <span className='dropdown-heading-text'>How do I get a copy of my record?</span>
           {isAccordionShown[1].display ? 
             <img src={openeddropdown} alt='Dropdown Icon' className='dropdown-icon-image'></img> :
@@ -67,7 +67,7 @@ const AccordionExample = () => {
       </div>
 
       <div className='faq-each-div'>
-        <button id='extra-charge' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 2)} onMouseDown={(event) => handleAccordionClick(event, 2)} aria-pressed={false} aria-expanded={false} aria-label='Expand information on extra charge for copy of record'>
+        <button id='extra-charge' className='dropdown-button block-interactive' onKeyDown={(event) => handleAccordionClick(event, 2)} onMouseDown={(event) => handleAccordionClick(event, 2)} aria-expanded={false} aria-label='Expand information on extra charge for copy of record'>
           <span className='dropdown-heading-text'>Is there a charge for extra copies?</span>
           {isAccordionShown[2].display ? 
             <img src={openeddropdown} alt='Dropdown Icon' className='dropdown-icon-image'></img> :
@@ -90,22 +90,22 @@ export default AccordionExample`
 
 // eslint-disable-next-line react/prop-types
 const Accordions = ({darkMode, setDarkMode}) => {
-    const page = 'accordions'
-    const[showDropdownPage, setShowDropdownPage] = useState(false);
+  const page = 'accordions'
+  const[showDropdownPage, setShowDropdownPage] = useState(false);
 
-    useEffect(() => {
-        if(showDropdownPage) {
-          document.querySelector('body').classList.add('no-scroll')
-        } else {
-          document.querySelector('body').classList.remove('no-scroll')
-        }
-    },[showDropdownPage])
+  useEffect(() => {
+    if(showDropdownPage) {
+      document.querySelector('body').classList.add('no-scroll')
+    } else {
+      document.querySelector('body').classList.remove('no-scroll')
+    }
+  },[showDropdownPage])
     
-    useEffect(() => {
-      const cleanUp = makeBlockAccessible('inner-body-div', 'block-interactive')
-    
-      return cleanUp
-    },[])
+  useEffect(() => {
+    const cleanUp = makeBlockAccessible('inner-body-div', 'block-interactive')
+
+    return cleanUp
+  },[])
 
   return (
     <div id="inner-body-div" className='accordion-example-page-div'>
@@ -120,7 +120,7 @@ const Accordions = ({darkMode, setDarkMode}) => {
                   <h1 className='component-example-heading'>Accordion</h1>
                   <span>A vertically stacked component that expands and collapses to reveal and hide content respectively. The difference between this and a menu is that a menu has a list interactive items, with the first item being focused when the menu is opened, while an accordion only contains non-interactive content.</span>
                   <p>If you have a component with a combination of both interactive and non-interactive elements, that requires the interactive elements to be keyboard interactive and focused, use a menu instead.</p>
-                  <p>The updateAccordionTriggerAriaAttributes function enables screen reader support for the accordions. This feature helps visually impaired users to navigate interacting with the accordions, by informing the users about the current state, and purpose, of each of the accordion. The states are either expanded or not expanded. The function updates the aria-pressed, aria-expanded and aria-label attributes of the accordion toggle button.</p>
+                  <p>The updateAccordionTriggerAriaAttributes function enables screen reader support for the accordions. This feature helps visually impaired users to navigate interacting with the accordions, by informing the users about the current state, and purpose, of each of the accordion. The states are either expanded or not expanded. The function updates the aria-expanded and aria-label attributes of the accordion toggle button.</p>
                   <p>The function accepts 3 arguments; an array of objects with information about each accordion in the collection, a shared class of all the accordion triggers, and the index position of the currently clicked trigger relative to the main accordion container and other trigger buttons.</p>
                   <p>The toggle buttons have keyboard interaction support using the makeBlockAccessible function.</p>
                   <AccordionExample/>

--- a/src/pages/Documentation.jsx
+++ b/src/pages/Documentation.jsx
@@ -7,7 +7,7 @@ import HomeExampleMenu from '../components/menus/HomeExampleMenu'
 import HomeTabExampleOne from '../components/tabs/HomeTabExampleOne'
 import { makeBlockAccessible } from 'aria-ease'
 
-const menuCode = `makeMenuAccessible('custom-menu', 'profile-menu-item')`
+const menuCode = `makeMenuAccessible('custom-menu', 'profile-menu-item', 'Display profile menu')`
 const updateHideCode = `updateMenuTriggerAriaAttributes('display-button', 'Hide profile menu')`
 const updateDisplayCode = `updateMenuTriggerAriaAttributes('display-button', 'Display profile menu')`
 const tabCode = `makeBlockAccessible('custom-tab', 'custom-tab-item')`
@@ -32,6 +32,7 @@ const handleAccordionClick = (event, index) => {
     });
   }
 };`
+
 
 // eslint-disable-next-line react/prop-types
 const Documentation = ({darkMode, setDarkMode}) => {
@@ -81,7 +82,7 @@ const Documentation = ({darkMode, setDarkMode}) => {
                       </p>
                       <HomeExampleMenu/>
                       <p className='feature-function-info-text'>The function creates a focus trap within the menu and focus can be navigated using the Arrow keys and Tab key. The Escape key closes the menu and returns the focus back to the trigger button. The Enter and Space keys &quot;click&quot; the interactive element (currently supports buttons, links, radios and checkboxes).</p>
-                      <p>The function takes two string arguments; the id of the menu div, and the class name of the children items of the menu.</p>
+                      <p>The makeMenuAccessible function takes three string arguments; the id of the menu, the class name of the children item of the menu, and the aria-label for the closed/hidden state of the menu.</p>
                       <div className='code-div'>
                         <code>{menuCode}</code>
                       </div>
@@ -91,9 +92,9 @@ const Documentation = ({darkMode, setDarkMode}) => {
                     <>
                       <p style={{marginTop: '80px'}}>
                         <b className='features-function'>updateMenuTriggerAriaAttributes:</b>
-                        This function updates the aria attributes of the menu trigger button. The aria-pressed, aria-expanded and aria-label attributes of the trigger button are toggled based on the current visibility of the menu. 
+                        This function updates the aria attributes of the menu trigger button. The aria-expanded and aria-label attributes of the trigger button are updated based on the current visibility of the menu. 
                       </p>
-                      <p>The function takes two string arguments; the id of the trigger button, and the aria-label that will replace the current one in the DOM. The aria-pressed and aria-expanded attributes get toggle to either true or false.</p>
+                      <p>The function takes two string arguments; the id of the trigger button, and the aria-label that will replace the current one in the DOM. The aria-expanded attribute gets toggled to either true or false.</p>
                       <p>Call the function as below when the menu is displayed. It updates the aria label of the trigger button to indicate that the menu is open and the button will close it.</p>
                       <div className='code-div'>
                         <code>{updateHideCode}</code>
@@ -140,14 +141,14 @@ const Documentation = ({darkMode, setDarkMode}) => {
                         This function enables screen reader support for accordions.
                       </p>
                       <p>This feature helps visually impaired users to navigate interacting with the accordions, by informing the users about the current state, and purpose, of each of the accordion. The states are either expanded or not expanded.</p>
-                      <p>The function updates the aria-pressed, aria-expanded and aria-label attributes of the accordion toggle button.</p>
+                      <p>The function updates the aria-expanded and aria-label attributes of the accordion toggle button.</p>
                       <p>The function accepts 3 arguments; an array of objects with information about each accordion in the collection, a shared class of all the accordion triggers, and the index position of the currently clicked trigger relative to the main accordion container and other trigger buttons.</p>
                       <pre>
-                          <div className='code-div'>
-                            <code>
-                              {accordionCode}
-                            </code>
-                          </div>
+                        <div className='code-div'>
+                          <code>
+                            {accordionCode}
+                          </code>
+                        </div>
                       </pre>
                       <p>The updateAccordionTriggerAriaAttributes should be called with the new state after the display state for the corresponding accordion has been updated to true/false and the accordion content has become  added to/removed from the DOM.</p>
                     </>

--- a/src/pages/Examples.jsx
+++ b/src/pages/Examples.jsx
@@ -6,7 +6,6 @@ import { useState, useEffect } from 'react'
 import { makeBlockAccessible } from 'aria-ease'
 import HomeExampleMenu from '../components/menus/HomeExampleMenu'
 
-
 const firstMenuCode = `import { makeMenuAccessible, updateMenuTriggerAriaAttributes, cleanUpMenuEventListeners } from 'aria-ease'
 
 const HomeExampleMenu = () => {
@@ -16,7 +15,7 @@ const HomeExampleMenu = () => {
       const menu = document.querySelector('#custom-menu');
       if (getComputedStyle(menu).display === 'none') {
         menu.style.display = 'block';
-        makeMenuAccessible('custom-menu', 'profile-menu-item');
+        makeMenuAccessible('custom-menu', 'profile-menu-item', 'Display profile menu');
         updateMenuTriggerAriaAttributes('display-button', 'Hide profile menu');
       } else {
         cleanUpMenuEventListeners('custom-menu', 'profile-menu-item');
@@ -32,7 +31,7 @@ const HomeExampleMenu = () => {
         id="display-button"
         onMouseDown={toggleMenuDisplay}
         aria-haspopup={true}
-        aria-pressed={false}
+        role="button"
         aria-expanded={false}
         aria-controls="custom-menu"
         aria-label="Display profile menu"
@@ -86,7 +85,7 @@ const Examples = ({darkMode, setDarkMode}) => {
 
                   <div className='example-each-ui-code-block-div'>
                     <h3 className=''>Buttons Menu</h3>
-                    <p>This creates a focus trap within the displayed menu. The Arrow keys navigates the focus within the trap in a cycle. The Space and Enter keys &#34;clicks&#34; the interactive element. The Escape key returns the focus back to the button that toggles the menu, which can then be clicked with the Enter or Space key to close the menu (provided keyboard interaction is added to the toggle button). The Tab key exits the trap.</p>
+                    <p>This creates a focus trap within the displayed menu. The Arrow keys navigates the focus within the trap in a cycle. The Space and Enter keys &#34;clicks&#34; the interactive element. The Escape key closes the menu, and returns the focus back to the button that toggles the menu. The Tab key exits the trap.</p>
                     <p>The toggle button has keyboard interaction support using the makeBlockAccessible function.</p>
                     <HomeExampleMenu/>
                     <pre>
@@ -97,7 +96,7 @@ const Examples = ({darkMode, setDarkMode}) => {
                       </div>
                     </pre>
                     <p>The onMouseDown and onKeyDown event handlers are used in place of the onClick event handler because the package uses a click() function to handle key press, which means if using the onClick event, two events are being acted upon, which leads to a conflict and irregular results.</p>
-                    <p>When you click on an element that has been enabled for keyboard interaction using the package, with the keyboard, on the package end a keydown event listens for key interactions and carries out a respective action based on the pressed key. Using the onClick event handler in the component carries out the same action which causes unexpected results, hence using onMouseDown and onKeyDown in the component.</p>
+                    <p>When you click on an element that has been enabled for keyboard interaction using the package, with the keyboard, on the package end a keydown event listens for key interactions and carries out a respective action based on the pressed key. Using the onClick event handler in the component carries out the same action which causes unexpected results, hence using onMouseDown and onKeyDown on the button to trigger it.</p>
                   </div>
                 </div>
               </Col>

--- a/src/pages/TabExamples.jsx
+++ b/src/pages/TabExamples.jsx
@@ -59,6 +59,7 @@ const TextInputBlock = () => {
 
 export default TextInputBlock`
 
+
 // eslint-disable-next-line react/prop-types
 const TabExamples = ({darkMode, setDarkMode}) => {
   const[showDropdownPage, setShowDropdownPage] = useState(false);


### PR DESCRIPTION
fix: fixed screen reader misinterpreting menu and accordion buttons as checkboxes. updated aria-ease npm package to latest version. refactored documentation copy to reflect the upda tes to the package